### PR TITLE
Add support for split slides with RStudio sections

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -18,7 +18,7 @@ normalize_path = function(path) {
 
 split_yaml_body = function(file) {
   x = readLines(file, encoding = 'UTF-8')
-  i = grep('^---\\s*$', x)
+  i = grep('^(---|===|###)\\s*$', x)
   n = length(x)
   if (length(i) < 2) {
     list(yaml = character(), body = x)


### PR DESCRIPTION
Fix #67

Now you split slides with any of  "---", "===" or "###".